### PR TITLE
Fix: Initialize global flags for CLI in correct place

### DIFF
--- a/docs/cli/release-log.md
+++ b/docs/cli/release-log.md
@@ -13,7 +13,13 @@ release-log [flags]
 ### Options
 
 ```
-  -h, --help   help for release-log
+      --first-version string    The first release version which should be initally used (default "v0.0.1")
+  -g, --git-executable string   The system-wide used Git executable (default "git")
+  -r, --git-remote string       Git remote which should be used for comparison (default "origin")
+  -u, --git-repo-url string     Git repository URL which could be overwritten. (If no URL is given the one of the git-remote is used)
+  -h, --help                    help for release-log
+      --latest-version string   Latest Git release version tag to be used (if not given it will be detected automatically using git)
+      --new-version string      New Git release version tag to be used (if not given it will be detected automatically using git)
 ```
 
 ### SEE ALSO

--- a/docs/cli/release-log_changelog.md
+++ b/docs/cli/release-log_changelog.md
@@ -16,6 +16,17 @@ release-log changelog [flags]
   -h, --help   help for changelog
 ```
 
+### Options inherited from parent commands
+
+```
+      --first-version string    The first release version which should be initally used (default "v0.0.1")
+  -g, --git-executable string   The system-wide used Git executable (default "git")
+  -r, --git-remote string       Git remote which should be used for comparison (default "origin")
+  -u, --git-repo-url string     Git repository URL which could be overwritten. (If no URL is given the one of the git-remote is used)
+      --latest-version string   Latest Git release version tag to be used (if not given it will be detected automatically using git)
+      --new-version string      New Git release version tag to be used (if not given it will be detected automatically using git)
+```
+
 ### SEE ALSO
 
 * [release-log](release-log.md)	 - CLI tool for Git release version tags and logs

--- a/docs/cli/release-log_full.md
+++ b/docs/cli/release-log_full.md
@@ -16,6 +16,17 @@ release-log full [flags]
   -h, --help   help for full
 ```
 
+### Options inherited from parent commands
+
+```
+      --first-version string    The first release version which should be initally used (default "v0.0.1")
+  -g, --git-executable string   The system-wide used Git executable (default "git")
+  -r, --git-remote string       Git remote which should be used for comparison (default "origin")
+  -u, --git-repo-url string     Git repository URL which could be overwritten. (If no URL is given the one of the git-remote is used)
+      --latest-version string   Latest Git release version tag to be used (if not given it will be detected automatically using git)
+      --new-version string      New Git release version tag to be used (if not given it will be detected automatically using git)
+```
+
 ### SEE ALSO
 
 * [release-log](release-log.md)	 - CLI tool for Git release version tags and logs

--- a/docs/cli/release-log_latest-version.md
+++ b/docs/cli/release-log_latest-version.md
@@ -16,6 +16,17 @@ release-log latest-version [flags]
   -h, --help   help for latest-version
 ```
 
+### Options inherited from parent commands
+
+```
+      --first-version string    The first release version which should be initally used (default "v0.0.1")
+  -g, --git-executable string   The system-wide used Git executable (default "git")
+  -r, --git-remote string       Git remote which should be used for comparison (default "origin")
+  -u, --git-repo-url string     Git repository URL which could be overwritten. (If no URL is given the one of the git-remote is used)
+      --latest-version string   Latest Git release version tag to be used (if not given it will be detected automatically using git)
+      --new-version string      New Git release version tag to be used (if not given it will be detected automatically using git)
+```
+
 ### SEE ALSO
 
 * [release-log](release-log.md)	 - CLI tool for Git release version tags and logs

--- a/docs/cli/release-log_new-version.md
+++ b/docs/cli/release-log_new-version.md
@@ -16,6 +16,17 @@ release-log new-version [flags]
   -h, --help   help for new-version
 ```
 
+### Options inherited from parent commands
+
+```
+      --first-version string    The first release version which should be initally used (default "v0.0.1")
+  -g, --git-executable string   The system-wide used Git executable (default "git")
+  -r, --git-remote string       Git remote which should be used for comparison (default "origin")
+  -u, --git-repo-url string     Git repository URL which could be overwritten. (If no URL is given the one of the git-remote is used)
+      --latest-version string   Latest Git release version tag to be used (if not given it will be detected automatically using git)
+      --new-version string      New Git release version tag to be used (if not given it will be detected automatically using git)
+```
+
 ### SEE ALSO
 
 * [release-log](release-log.md)	 - CLI tool for Git release version tags and logs

--- a/docs/cli/release-log_title.md
+++ b/docs/cli/release-log_title.md
@@ -16,6 +16,17 @@ release-log title [flags]
   -h, --help   help for title
 ```
 
+### Options inherited from parent commands
+
+```
+      --first-version string    The first release version which should be initally used (default "v0.0.1")
+  -g, --git-executable string   The system-wide used Git executable (default "git")
+  -r, --git-remote string       Git remote which should be used for comparison (default "origin")
+  -u, --git-repo-url string     Git repository URL which could be overwritten. (If no URL is given the one of the git-remote is used)
+      --latest-version string   Latest Git release version tag to be used (if not given it will be detected automatically using git)
+      --new-version string      New Git release version tag to be used (if not given it will be detected automatically using git)
+```
+
 ### SEE ALSO
 
 * [release-log](release-log.md)	 - CLI tool for Git release version tags and logs

--- a/docs/cli/release-log_version.md
+++ b/docs/cli/release-log_version.md
@@ -16,6 +16,17 @@ release-log version [flags]
   -h, --help   help for version
 ```
 
+### Options inherited from parent commands
+
+```
+      --first-version string    The first release version which should be initally used (default "v0.0.1")
+  -g, --git-executable string   The system-wide used Git executable (default "git")
+  -r, --git-remote string       Git remote which should be used for comparison (default "origin")
+  -u, --git-repo-url string     Git repository URL which could be overwritten. (If no URL is given the one of the git-remote is used)
+      --latest-version string   Latest Git release version tag to be used (if not given it will be detected automatically using git)
+      --new-version string      New Git release version tag to be used (if not given it will be detected automatically using git)
+```
+
 ### SEE ALSO
 
 * [release-log](release-log.md)	 - CLI tool for Git release version tags and logs

--- a/internal/app/cmd/full.go
+++ b/internal/app/cmd/full.go
@@ -44,7 +44,7 @@ func newFullCmd() *cobra.Command {
 				printCliErrorAndExit(err)
 			}
 
-			fmt.Println(releaseTitle + "\n\n")
+			fmt.Println(releaseTitle + "\n")
 			fmt.Printf("New version: %s\n", newVersionTag)
 
 			if latestVersionTag != "" && releaseCompareUrl != "" {


### PR DESCRIPTION
* Initialize global flags for CLI in the correct place
* Generate CLI documentation with correct flags and options